### PR TITLE
Adds simple instuction format

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,4 +12,5 @@ dependencies {
     compile 'org.json:json:20131018'
     testCompile 'junit:junit:4.10'
     testCompile 'org.apache.commons:commons-io:1.3.2'
+    testCompile 'org.easytesting:fest-assert-core:2.0M10'
 }

--- a/src/main/java/com/mapzen/osrm/Instruction.java
+++ b/src/main/java/com/mapzen/osrm/Instruction.java
@@ -48,6 +48,9 @@ public class Instruction {
         setDistance(json.getInt(2));
     }
 
+    protected Instruction() {
+    }
+
     public void setTurnInstruction(int turn) {
         this.turn = turn;
     }
@@ -156,6 +159,10 @@ public class Instruction {
                 getFullInstructionPattern(),
                 getHumanTurnInstruction(),
                 getName(), getHumanDistance(Locale.ENGLISH));
+    }
+
+    public String getSimpleInstruction() {
+        return String.format(Locale.ENGLISH, "%s %s", getHumanTurnInstruction(), getName());
     }
 
     @Override

--- a/src/test/java/com/mapzen/osrm/InstructionTest.java
+++ b/src/test/java/com/mapzen/osrm/InstructionTest.java
@@ -1,6 +1,5 @@
 package com.mapzen.osrm;
 
-import org.hamcrest.CoreMatchers;
 import org.json.JSONArray;
 import org.junit.Before;
 import org.junit.Test;
@@ -9,11 +8,8 @@ import java.util.ArrayList;
 import java.util.Locale;
 
 import static com.mapzen.osrm.Instruction.*;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.core.Is.is;
+import static org.fest.assertions.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class InstructionTest {
     private Instruction instruction;
@@ -430,6 +426,11 @@ public class InstructionTest {
         double lat1 = point[0];
         double lng1 = point[1];
         double[] expectedMidpoint = {((lat1+lat2)/2), ((lng1+lng2)/2) };
-        assertThat(midPoint, equalTo(expectedMidpoint));
+        assertThat(midPoint).isEqualTo(expectedMidpoint);
+    }
+
+    @Test
+    public void testSimpleInstruction() throws Exception {
+        assertThat(instruction.getSimpleInstruction()).isEqualTo("Head on 19th Street");
     }
 }


### PR DESCRIPTION
- Simple instruction gives turn and street name without distance and "glue".
- Useful as abbreviated instuction format (such as in a list view).
- Also adds protected no argument constuctor to enable testing via subclass.
