### PR TITLE
Adds ability to deploy geojson as maven dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.gradle/
 build
 .idea/
 *.iml

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,21 @@
+buildscript {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+    }
+
+    dependencies {
+        classpath 'org.gradle.api.plugins:gradle-nexus-plugin:0.2'
+    }
+}
+
 apply plugin: 'java'
 apply plugin: 'java-library-distribution'
-apply from: 'http://www.tellurianring.com/projects/gradle-plugins/gradle-templates/1.3/apply.groovy'
+apply plugin: 'maven'
+apply plugin: 'nexus'
+
+group = 'com.mapzen'
+version = '0.1-SNAPSHOT'
 
 defaultTasks = ['clean', 'test', 'jar']
 
@@ -13,4 +28,16 @@ dependencies {
     testCompile 'junit:junit:4.10'
     testCompile 'org.apache.commons:commons-io:1.3.2'
     testCompile 'org.easytesting:fest-assert-core:2.0M10'
+}
+
+install {
+    repositories.mavenInstaller {
+        pom.artifactId = 'geojson'
+    }
+}
+
+uploadArchives {
+    repositories.mavenDeployer {
+        pom.artifactId = 'geojson'
+    }
 }


### PR DESCRIPTION
- Updates build.gradle
- Adds maven and nexus gradle plugins
- Removes gradle-templates plugin (used for project setup only; website frequently down)

To deploy geojson jar to local .m2 repo run:

<pre>
$ gradle clean test install
</pre>


Then it can be included in your gradle project using:

<pre>
compile 'com.mapzen:geojson:0.1-SNAPSHOT'
</pre>


or maven using:

```
<dependency>
    <groupId>com.mapzen</groupId>
    <artifactId>geojson</artifactId>
    <version>0.1-SNAPSHOT</version>
</dependency>
```
