### PR TITLE
Updates build.gradle for Jenkins CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'nexus'
 group = 'com.mapzen'
 version = '0.1-SNAPSHOT'
 
-defaultTasks = ['clean', 'test', 'jar']
+defaultTasks = ['clean', 'test', 'install']
 
 repositories {
     maven { url 'http://repo.maven.apache.org/maven2' }
@@ -28,6 +28,20 @@ dependencies {
     testCompile 'junit:junit:4.10'
     testCompile 'org.apache.commons:commons-io:1.3.2'
     testCompile 'org.easytesting:fest-assert-core:2.0M10'
+}
+
+def defaultEncoding = 'UTF-8'
+
+compileJava {
+    options.encoding = defaultEncoding
+}
+
+compileTestJava {
+    options.encoding = defaultEncoding
+}
+
+javadoc {
+    options.encoding = defaultEncoding
 }
 
 install {


### PR DESCRIPTION
- Replaces `clean test jar` with `clean test install` as default tasks
- Adds UTF-8 encoding for `compileJava`, `compileTestJava`, and `javadoc` tasks
